### PR TITLE
.eslintrc.js のエラーを修正

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,10 +12,9 @@ module.exports = {
   extends: [
     '@nuxtjs',
     'plugin:nuxt/recommended',
-    'prettier',
-    'prettier/vue'
+    'prettier'
   ],
-  plugins: ['prettier'],
+  plugins: [],
   // add your custom rules here
   rules: {
     semi: [2, 'never'],

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,7 +7,7 @@
           <circle cx="117.118" cy="292.227" r="13.5" fill="#C4C4C4"/>
           <circle cx="245.118" cy="292.227" r="13.5" fill="#C4C4C4"/>
         </g>
-        <g id='nose' v-on:click="clickOn">
+        <g id='nose' @click="clickOn">
           <path d="M177.972 373.788C179.797 375.348 182.473 375.39 184.347 373.888L212.618 351.227C215.621 348.036 213.428 342.727 209.046 342.727H155.167C150.521 342.727 148.387 348.51 151.919 351.528L177.972 373.788Z" fill="#C4C4C4"/>
           <ellipse cx="181.618" cy="346.727" rx="32" ry="13" fill="#C4C4C4"/>
         </g>
@@ -43,30 +43,29 @@
 export default {
   methods: {
     clickOn () {
-      const nose = document.getElementById('nose')
-      let eyes = document.getElementById('eyes')
+      const eyes = document.getElementById('eyes')
       const nomalEyes = '<circle cx="117.118" cy="292.227" r="13.5" fill="#C4C4C4"/><circle cx="245.118" cy="292.227" r="13.5" fill="#C4C4C4"/>'
       const blink80 = '<circle cx="245.118" cy="292.227" r="13.5" fill="#C4C4C4"/><ellipse cx="238.265" cy="274.5" rx="20.2645" ry="11.5" fill="white"/><circle cx="117.118" cy="292.227" r="13.5" fill="#C4C4C4"/><ellipse cx="127.265" cy="274.5" rx="20.2645" ry="11.5" fill="white"/>'
       const blink50 = '<circle cx="245.118" cy="292.227" r="13.5" fill="#C4C4C4"/><ellipse cx="238.265" cy="279.5" rx="20.2645" ry="11.5" fill="white"/><circle cx="117.118" cy="292.227" r="13.5" fill="#C4C4C4"/><ellipse cx="127.265" cy="279.5" rx="20.2645" ry="11.5" fill="white"/>'
       const blink0 = '<circle cx="245.118" cy="292.227" r="13.5" fill="#C4C4C4"/><ellipse cx="236.265" cy="281.5" rx="20.2645" ry="11.5" fill="white"/><path d="M227.769 297.245C230.949 305.954 240.333 310.545 248.728 307.499C257.124 304.453 267.109 292.767 263.929 284.058C269.233 274.097 264.033 291.128 245.274 298.037C236.878 301.083 227.769 297.245 227.769 297.245Z" fill="white"/><circle cx="117.118" cy="292.227" r="13.5" fill="#C4C4C4"/><ellipse cx="125.265" cy="281.5" rx="20.2645" ry="11.5" fill="white"/><path d="M131.926 296.285C128.754 305 119.378 309.588 110.985 306.533C102.592 303.478 92.6042 291.776 95.776 283.062C90.4674 273.089 95.6774 290.138 114.431 297.065C122.824 300.12 131.926 296.285 131.926 296.285Z" fill="white"/>'
 
     setTimeout(function() {
-      eyes.innerHTML = blink80;
+      eyes.innerHTML = blink80
       }, 100)
     setTimeout(function() {
-      eyes.innerHTML = blink50;
+      eyes.innerHTML = blink50
       }, 200)
     setTimeout(function() {
-      eyes.innerHTML = blink0;
+      eyes.innerHTML = blink0
       }, 300)
     setTimeout(function() {
-      eyes.innerHTML = blink50;
+      eyes.innerHTML = blink50
       }, 600)
     setTimeout(function() {
-      eyes.innerHTML = blink80;
+      eyes.innerHTML = blink80
       }, 700)
     setTimeout(function() {
-      eyes.innerHTML = nomalEyes;
+      eyes.innerHTML = nomalEyes
       }, 800)
     }
   }


### PR DESCRIPTION
## 概要
`.eslintrc.js` のエラー修正のため、以下を行いました。

1b644d9 `prettier/vue` の記述を削除
8a3b18c ESlint に従って、指摘されたコードを修正

## 確認方法
以下を実行し、エラーが発生しないことを確認してください。

- `npm run dev`
- `npm run lint`

## チェックリスト
- [x] Lint のチェックをパスした
